### PR TITLE
Necessary updates due to recent docker compose and devcontainer config changes

### DIFF
--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -18,24 +18,20 @@ Once complete, VS Code will be running in your browser with the master branch cl
 
 ## Setup RedDog Environment
 
-1. In a VS Code terminal window, run the following to trust local certs:
-```
-dotnet dev-certs https --trust
-```
-2. Start the Bootstrapper Dapr sidecar by doing the following:
+1. Start the Bootstrapper Dapr sidecar by doing the following:
     1. Open the Command Palette
     2. Select `Tasks: Run Task`
     3. Select `Dapr Bootstrapper`
-3. In a VS Code terminal window, set an environment variable for the Bootstrapper's Dapr HTTP Port
+2. In a VS Code terminal window, set an environment variable for the Bootstrapper's Dapr HTTP Port
 ```
 DAPR_HTTP_PORT=5880
 ```
-4. Switch to the Run and Debug screen and debug the Bootstrapper.  Upon completion, you should now have a "reddogdemo" database in the given SQL Server instance.
+3. Switch to the Run and Debug screen and debug the Bootstrapper.  Upon completion, you should now have a "reddogdemo" database in the given SQL Server instance.
 
 >The Accounting Service within RedDog relies on SQL Server for persistent storage.  As such, you will notice that the `.devcontainer` configuration for Codespaces (located withing the `.devcontainer` folder) points at a Docker compose file that includes a container image reference to SQL Server.  While the image will be pulled into your Codespace for you, the database itself will still need to be provisioned.  Included in the RedDog repo is an EF Core migration that can be run to provision the database.  This migration functionality is located within RedDog.Bootstrapper. 
 
 >The SQL Server command-line tools have been installed for you.  If desired, execute the following to connect via sqlcmd:<br> 
->sqlcmd -S reddog-code_devcontainer_db_1,1433 -U SA -P "pass@word1" -d reddogdemo<br><br>
+>sqlcmd -S reddog-sql-server,1433 -U SA -P "pass@word1" -d reddogdemo<br><br>
 >Execute the following to verify that RedDog tables have been created:<br>
 > ```1>SELECT Name FROM sys.tables```<br>
 > ```2>GO```


### PR DESCRIPTION
Adjusted documentation to reflect recent docker compose and devcontainer config changes including:

- No longer necessary to include the instructions for trusting local certs (this now happens in the postCreateCommand of the Codespace)
- Adjusted the sql server connection string mentioned in the docs now that the hostname of the sql server is being explicitly set (found in .devcontainer/docker-compose.yml)